### PR TITLE
Update to Dart 3.5.0 and Flutter 3.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.2
+- iOS: Downgrade Appsflyer SDK iOS dependency from 6.14.3 to 6.13.0
+- Update to Dart `3.5.0` and Flutter `3.24.0`
+
 ## 4.0.1
 - iOS: Update Appsflyer SDK iOS dependency 6.14.3
 - Update to Dart `3.4.3` and Flutter `3.22.2`

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -33,7 +33,7 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   pod 'Segment-Firebase', :git => "https://github.com/foxanna/analytics-ios-integration-firebase" , :tag => '2.7.15'
-  pod 'segment-appsflyer-ios', '6.14.3'
+  pod 'segment-appsflyer-ios', '6.13.0'
 end
 
 post_install do |installer|

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.1"
+    version: "4.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -83,18 +83,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -115,18 +115,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -184,10 +184,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -200,10 +200,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.4"
 sdks:
-  dart: ">=3.4.3 <4.0.0"
-  flutter: ">=3.22.2"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/ios/flutter_segment.podspec
+++ b/ios/flutter_segment.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_segment'
-  s.version          = '4.0.1'
+  s.version          = '4.0.0'
   s.summary          = 'Segment.io plugin for Flutter'
   s.description      = <<-DESC
 Library to let Flutter apps use Segment.io
@@ -19,7 +19,7 @@ Library to let Flutter apps use Segment.io
   s.dependency 'Flutter'
   s.dependency 'Analytics', '4.1.6'
   s.dependency 'Segment-Amplitude', '3.3.2'
-  s.dependency 'segment-appsflyer-ios', '6.14.3'
+  s.dependency 'segment-appsflyer-ios', '6.13.0'
   s.dependency 'Segment-Firebase', '2.7.15'
   s.ios.deployment_target = '11.0'
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -68,18 +68,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -108,18 +108,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -177,10 +177,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -193,10 +193,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.4"
 sdks:
-  dart: ">=3.4.3 <4.0.0"
-  flutter: ">=3.22.2"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_segment
 description: Flutter implementation of Segment Analytics for iOS, Android and Web
-version: 4.0.1
+version: 4.0.2
 homepage: https://lahaus.com
 repository: https://github.com/la-haus/flutter-library-segment
 issue_tracker: https://github.com/la-haus/flutter-library-segment/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,15 +7,15 @@ issue_tracker: https://github.com/la-haus/flutter-library-segment/issues
 documentation: https://github.com/la-haus/flutter-library-segment#readme
 
 environment:
-  sdk: ^3.4.3
-  flutter: ^3.22.2
+  sdk: ^3.5.0
+  flutter: ^3.24.0
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: 1.12.0
+  meta: 1.15.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Running `flutter pub get` on a flutter 3.24 project that depends on `flutter_segment` fails, output:
```
Because every version of flutter from sdk depends on meta 1.15.0 and every version of flutter_segment from git depends on meta 1.12.0, flutter from sdk is incompatible with flutter_segment from git.
```

This PR updates `meta` to version `1.15.0` - as required by Flutter 3.24.0
And it also updates pubspec.yaml to target Flutter 3.24.0 and Dart 3.5.0

Reverts #4 